### PR TITLE
Next 85992 change customer password

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
@@ -115,7 +115,6 @@
                     :disabled="customer.guest"
                     :label="$tc('sw-customer.baseForm.labelPassword')"
                     :placeholder="$tc('sw-customer.baseForm.placeholderPassword')"
-                    :helpText="$tc('sw-customer.baseForm.helpTextPassword')"
                     :error="customerPasswordError"
                     autocomplete="new-password">
                 </sw-password-field>

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig
@@ -106,6 +106,24 @@
                                                 </sw-entity-tag-select>
                                             {% endblock %}
 
+                                            {% block sw_customer_card_password %}
+                                                <sw-password-field v-if="editMode"
+                                                                   v-model="customer.passwordNew"
+                                                                   autocomplete="off"
+                                                                   :label="$tc('sw-profile.index.labelNewPassword')"
+                                                                   :placeholder="$tc('sw-customer.card.placeholderNewPassword')">
+                                                </sw-password-field>
+                                            {% endblock %}
+
+                                            {% block sw_customer_card_password_confirm %}
+                                                <sw-password-field v-if="editMode"
+                                                                   v-model="customer.passwordConfirm"
+                                                                   autocomplete="off"
+                                                                   :label="$tc('sw-profile.index.labelNewPasswordConfirm')"
+                                                                   :placeholder="$tc('sw-customer.card.placeholderNewPasswordConfirm')">
+                                                </sw-password-field>
+                                            {% endblock %}
+
                                             {% block sw_customer_card_metadata_additional %}
                                                 <slot name="metadata-additional">
                                                     {% block sw_customer_card_slot_metadata_additional %}{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/index.js
@@ -154,10 +154,25 @@ Component.register('sw-customer-detail', {
                 this.customer.birthday = null;
             }
 
+            if (! this.checkPassword()) {
+                this.isLoading = false;
+                this.createNotificationError({
+                    title: this.$tc('sw-customer.detail.titleSaveError'),
+                    message: this.$tc('sw-customer.detail.notificationPasswordErrorMessage')
+                });
+                return false;
+            }
+
             return this.customerRepository.save(this.customer, Shopware.Context.api).then(() => {
                 this.isLoading = false;
                 this.isSaveSuccessful = true;
                 this.createdComponent();
+                this.createNotificationSuccess({
+                    title: this.$tc('sw-customer.detail.titleSaveSuccess'),
+                    message: this.$tc('sw-customer.detail.messageSaveSuccess',  0, {
+                        name: this.customer.firstName + ' ' + this.customer.lastName
+                    })
+                });
             }).catch((exception) => {
                 this.createNotificationError({
                     title: this.$tc('sw-customer.detail.titleSaveError'),
@@ -175,6 +190,20 @@ Component.register('sw-customer-detail', {
 
         onActivateCustomerEditMode() {
             this.editMode = true;
-        }
+        },
+
+        checkPassword() {
+            if ((this.customer.passwordNew && this.customer.passwordNew.length > 0) ||
+                (this.customer.passwordConfirm && this.customer.passwordConfirm.length > 0)
+                ) {
+                if (this.customer.passwordNew !== this.customer.passwordConfirm) {
+                    return false;
+                } else {
+                    this.customer.password = this.customer.passwordNew;
+                }
+            }
+
+            return true;
+        },
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
@@ -18,6 +18,8 @@
       "placeholderLastName": "Nachname",
       "placeholderCompany": "Firma",
       "placeholderEmail": "E-Mail-Adresse",
+      "placeholderNewPassword": "Neues Passwort eingeben ...",
+      "placeholderNewPasswordConfirm": "Neues Passwort erneut eingeben ...",
       "labelSalutation": "Anrede",
       "labelTitle": "Titel",
       "labelFirstName": "Vorname",
@@ -196,7 +198,8 @@
       "titleSaveError": "Fehler",
       "titleSaveSuccess": "Erfolg",
       "messageSaveError": "Der Kunde konnte nicht gespeichert werden.",
-      "messageSaveSuccess": "Der Kunde \"{name}\" wurde erfolgreich gespeichert."
+      "messageSaveSuccess": "Der Kunde \"{name}\" wurde erfolgreich gespeichert.",
+      "notificationPasswordErrorMessage": "Die eingegebenen Passwörter stimmen nicht überein."
     }
   }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
@@ -18,6 +18,8 @@
       "placeholderLastName": "Last name",
       "placeholderCompany": "Company",
       "placeholderEmail": "Email address",
+      "placeholderNewPassword": "Enter new password...",
+      "placeholderNewPasswordConfirm": "Re-enter new password...",
       "labelSalutation": "Salutation",
       "labelTitle": "Title",
       "labelFirstName": "First name",
@@ -196,7 +198,8 @@
       "titleSaveError": "Error",
       "titleSaveSuccess": "Success",
       "messageSaveError": "Customer could not be saved.",
-      "messageSaveSuccess": "Customer \"{name}\" has been saved."
+      "messageSaveSuccess": "Customer \"{name}\" has been saved.",
+      "notificationPasswordErrorMessage": "The submitted passwords do not match."
     }
   }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/index.js
@@ -34,6 +34,7 @@ Component.register('sw-settings-user-detail', {
             mediaItem: null,
             changePasswordModal: false,
             newPassword: '',
+            newPasswordConfirm: '',
             isEmailUsed: false,
             isUsernameUsed: false,
             isIntegrationsLoading: false,
@@ -93,13 +94,14 @@ Component.register('sw-settings-user-detail', {
         },
 
         disableConfirm() {
-            return this.newPassword === '' || this.newPassword === null;
+            return this.newPassword !== this.newPasswordConfirm || this.newPassword === '' || this.newPassword === null;
         },
 
         isCurrentUser() {
             if (!this.user || !this.currentUser) {
-                return true;
+                return false;
             }
+
             return this.userId === this.currentUser.id;
         },
 
@@ -345,14 +347,17 @@ Component.register('sw-settings-user-detail', {
 
         onClosePasswordModal() {
             this.newPassword = '';
+            this.newPasswordConfirm = '';
             this.changePasswordModal = false;
         },
 
-        onSubmit() {
-            this.changePasswordModal = false;
+        async onSubmit() {
             this.user.password = this.newPassword;
             this.newPassword = '';
-            this.onSave();
+            this.newPasswordConfirm = '';
+            await this.onSave();
+            this.user.password = '';
+            this.changePasswordModal = false;
         },
 
         onShowDetailModal(id) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/sw-settings-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/sw-settings-user-detail.html.twig
@@ -113,7 +113,7 @@
                                         {% endblock %}
 
                                         {% block sw_settings_user_detail_grid_change_password %}
-                                            <a v-if="!isCurrentUser" class="sw-settings-user-detail__grid-change-password" @click="onChangePassword">
+                                            <a v-if="isCurrentUser" class="sw-settings-user-detail__grid-change-password" @click="onChangePassword">
                                                 {{ $tc('sw-settings-user.user-detail.labelChangePassword') }}
                                             </a>
                                         {% endblock %}
@@ -151,6 +151,14 @@
                                                 :passwordToggleAble="true"
                                                 :copyAble="false"
                                                 :placeholder="$tc('sw-settings-user.user-detail.placeholderNewPassword')">
+                                            </sw-password-field>
+
+                                            <sw-password-field
+                                                class="sw-settings-user-detail__new-password"
+                                                v-model="newPasswordConfirm"
+                                                :passwordToggleAble="true"
+                                                :copyAble="false"
+                                                :placeholder="$tc('sw-settings-user.user-detail.placeholderNewPasswordConfirm')">
                                             </sw-password-field>
                                         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/snippet/de-DE.json
@@ -50,6 +50,7 @@
       "labelNewPassword": "Neues Passwort",
       "labelNewUser": "Neuer Benutzer",
       "placeholderNewPassword": "Neues Passwort eingeben ...",
+      "placeholderNewPasswordConfirm": "Neues Passwort erneut eingeben ...",
       "labelButtonCancel": "Abbrechen",
       "labelButtonChangePassword": "Ändern",
       "labelButtonSave": "Speichern",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/snippet/en-GB.json
@@ -50,6 +50,7 @@
       "labelNewPassword": "New password",
       "labelNewUser": "New user",
       "placeholderNewPassword": "Enter new password...",
+      "placeholderNewPasswordConfirm": "Re-enter new password...",
       "labelButtonCancel": "Cancel",
       "labelButtonChangePassword": "Change",
       "labelButtonSave": "Save",


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix for issue [#879](https://github.com/shopware/platform/issues/879)

### 2. What does this change do, exactly?
- First commit allows you to change a customers password from the admin page. 
- The second commit allows you to change the password of an admin user through the Settings -> Users & Permissions (instead of Your Profile). For now it only allows you to change your own password, but when admin roles gets added, it'll be easy to add so a super admin can change other admins passwords too.

### 3. Describe each step to reproduce the issue or behaviour.
If you go to the customer list, click on a customer and click edit. It should now show two more input fields, "new password" and "confirm new password". If both are equal and above 0 characters (you should probably add some password requirements for future reference), the password will be changed on the user. If the fields doesn't match, an error message will be shown.
Furthermore a success message for when editing a user has been added.

### 4. Please link to the relevant issues (if any).
[#879](https://github.com/shopware/platform/issues/879)

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
